### PR TITLE
Added dryRun option to uploads

### DIFF
--- a/src/upload.js
+++ b/src/upload.js
@@ -24,7 +24,7 @@ function uploadFile(path, customOptions = {}) {
   formData.append(opts.portalFileFieldname, fs.createReadStream(path), options);
 
   // Form the URL.
-  const url = `${trimTrailingSlash(opts.portalUrl)}${trimTrailingSlash(opts.portalUploadPath)}`;
+  let url = `${trimTrailingSlash(opts.portalUrl)}${trimTrailingSlash(opts.portalUploadPath)}`;
 
   if (opts.dryRun) url += "?dryrun=true";
 
@@ -64,7 +64,7 @@ function uploadDirectory(path, customOptions = {}) {
   }
 
   // Form the URL.
-  const url = `${trimTrailingSlash(opts.portalUrl)}${trimTrailingSlash(opts.portalUploadPath)}?filename=${
+  let url = `${trimTrailingSlash(opts.portalUrl)}${trimTrailingSlash(opts.portalUploadPath)}?filename=${
     opts.customFilename || path
   }`;
 

--- a/src/upload.js
+++ b/src/upload.js
@@ -13,6 +13,7 @@ const defaultUploadOptions = {
   portalFileFieldname: "file",
   portalDirectoryFileFieldname: "files[]",
   customFilename: "",
+  dryRun: false,
 };
 
 function uploadFile(path, customOptions = {}) {
@@ -24,6 +25,8 @@ function uploadFile(path, customOptions = {}) {
 
   // Form the URL.
   const url = `${trimTrailingSlash(opts.portalUrl)}${trimTrailingSlash(opts.portalUploadPath)}`;
+
+  if (opts.dryRun) url += "?dryrun=true";
 
   return new Promise((resolve, reject) => {
     axios
@@ -64,6 +67,8 @@ function uploadDirectory(path, customOptions = {}) {
   const url = `${trimTrailingSlash(opts.portalUrl)}${trimTrailingSlash(opts.portalUploadPath)}?filename=${
     opts.customFilename || path
   }`;
+
+  if (opts.dryRun) url += "&dryrun=true";
 
   return new Promise((resolve, reject) => {
     axios

--- a/src/upload.test.js
+++ b/src/upload.test.js
@@ -35,10 +35,11 @@ describe("uploadFile", () => {
       portalUploadPath: "/skynet/file",
       portalFileFieldname: "filetest",
       customFilename: "test.jpg",
+      dryRun: true,
     });
 
     expect(axios.post).toHaveBeenCalledWith(
-      `localhost/skynet/file`,
+      `localhost/skynet/file?dryrun=true`,
       expect.objectContaining({
         _streams: expect.arrayContaining([
           expect.stringContaining('Content-Disposition: form-data; name="filetest"; filename="test.jpg"'),
@@ -50,6 +51,12 @@ describe("uploadFile", () => {
 
   it("should return skylink on success", async () => {
     const data = await uploadFile(filename);
+
+    expect(data).toEqual(`${uriSkynetPrefix}${skylink}`);
+  });
+
+  it("should return skylink on success with dryRun", async () => {
+    const data = await uploadFile(filename, { dryRun: true });
 
     expect(data).toEqual(`${uriSkynetPrefix}${skylink}`);
   });
@@ -85,11 +92,12 @@ describe("uploadDirectory", () => {
       portalUploadPath: "/skynet/file",
       portalDirectoryFileFieldname: "filetest",
       customFilename: "testpath",
+      dryRun: true,
     });
 
     for (const file of directory) {
       expect(axios.post).toHaveBeenCalledWith(
-        `localhost/skynet/file?filename=testpath`,
+        `localhost/skynet/file?filename=testpath&dryrun=true`,
         expect.objectContaining({
           _streams: expect.arrayContaining([
             expect.stringContaining(`Content-Disposition: form-data; name="filetest"; filename="${file}"`),
@@ -102,6 +110,12 @@ describe("uploadDirectory", () => {
 
   it("should return single skylink on success", async () => {
     const data = await uploadDirectory(filename);
+
+    expect(data).toEqual(`${uriSkynetPrefix}${skylink}`);
+  });
+
+  it("should return single skylink on success with dryRun", async () => {
+    const data = await uploadDirectory(filename, { dryRun: true });
 
     expect(data).toEqual(`${uriSkynetPrefix}${skylink}`);
   });


### PR DESCRIPTION
Pretty straight forward.
If `dryRun` is enabled the `dryrun` option parameter gets passed to skynet, generating a skylink without uploading content to hosts.