### PR TITLE
Fix upload errors due to missing headers

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -29,6 +29,9 @@ class SkynetClient {
   executeRequest(config) {
     const url = makeUrl(config.portalUrl, config.endpointPath, config.extraPath ? config.extraPath : "");
 
+    if (!config.headers) {
+      config.headers = {};
+    }
     if (config.customUserAgent) {
       config.headers["User-Agent"] = config.customUserAgent;
     }

--- a/src/client.js
+++ b/src/client.js
@@ -29,12 +29,16 @@ class SkynetClient {
   executeRequest(config) {
     const url = makeUrl(config.portalUrl, config.endpointPath, config.extraPath ? config.extraPath : "");
 
+    if (config.customUserAgent) {
+      config.headers["User-Agent"] = config.customUserAgent;
+    }
+
     return axios({
       url: url,
       method: config.method,
       data: config.data,
       params: config.params,
-      headers: config.customUserAgent && { "User-Agent": config.customUserAgent },
+      headers: config.headers,
       auth: config.APIKey && { username: "", password: config.APIKey },
       responseType: config.responseType,
       onUploadProgress:

--- a/src/download.test.js
+++ b/src/download.test.js
@@ -49,4 +49,21 @@ describe("download", () => {
 
     tmpFile.removeCallback();
   });
+
+  it("should use custom connection options if defined on the client", () => {
+    const tmpFile = tmp.fileSync();
+    const client = new SkynetClient("", { APIKey: "foobar", customUserAgent: "Sia-Agent" });
+
+    client.downloadFile(tmpFile.name, skylink, { APIKey: "barfoo", customUserAgent: "Sia-Agent-2" });
+
+    expect(axios).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: `${portalUrl}/${skylink}`,
+        auth: { username: "", password: "barfoo" },
+        headers: expect.objectContaining({ "User-Agent": "Sia-Agent-2" }),
+      })
+    );
+
+    tmpFile.removeCallback();
+  });
 });

--- a/src/upload.test.js
+++ b/src/upload.test.js
@@ -26,10 +26,12 @@ describe("uploadFile", () => {
         url: `${portalUrl}/skynet/skyfile`,
         data: expect.objectContaining({
           _streams: expect.arrayContaining([
-            expect.stringContaining(`Content-Disposition: form-data; name="file"; filename="file1.txt"`),
+            expect.stringContaining(
+              'Content-Disposition: form-data; name="file"; filename="file1.txt"\r\nContent-Type: text/plain'
+            ),
           ]),
         }),
-        headers: expect.anything(),
+        headers: expect.objectContaining({ "content-type": expect.stringContaining("multipart/form-data") }),
         params: expect.anything(),
       })
     );

--- a/src/upload.test.js
+++ b/src/upload.test.js
@@ -1,4 +1,6 @@
 const axios = require("axios");
+const fs = require("fs");
+const tmp = require("tmp");
 
 const { SkynetClient, defaultPortalUrl, uriSkynetPrefix } = require("../index");
 
@@ -70,7 +72,7 @@ describe("uploadFile", () => {
           ]),
         }),
         auth: { username: "", password: "foobar" },
-        headers: { "User-Agent": "Sia-Agent" },
+        headers: expect.objectContaining({ "User-Agent": "Sia-Agent" }),
         params: expect.anything(),
       })
     );
@@ -90,10 +92,19 @@ describe("uploadFile", () => {
           ]),
         }),
         auth: { username: "", password: "barfoo" },
-        headers: { "User-Agent": "Sia-Agent-2" },
+        headers: expect.objectContaining({ "User-Agent": "Sia-Agent-2" }),
         params: expect.anything(),
       })
     );
+  });
+
+  it("should upload tmp files", async () => {
+    const file = tmp.fileSync({ postfix: ".json" });
+    fs.writeFileSync(file.fd, JSON.stringify("testing"));
+
+    const data = await client.uploadFile(file.name);
+
+    expect(data).toEqual(sialink);
   });
 
   it("should return skylink on success", async () => {


### PR DESCRIPTION
Looks like I messed this up during the executeRequest refactor. Headers were not
being propogated to axios properly and so the Content-Type header was always
missing. No one tested v2.0.0 so it went unnoticed. This will require a version
bump afterwards.